### PR TITLE
Add Jest tests for scripts

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,6 +31,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "my-website--abrahamoflondon",
+  "version": "1.0.0",
+  "description": "",
+  "main": "scripts.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/tests/scripts.test.js
+++ b/tests/scripts.test.js
@@ -1,0 +1,17 @@
+/**
+ * @jest-environment jsdom
+ */
+
+describe('scripts.js', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = '<span id="year"></span>';
+  });
+
+  test('updates #year textContent with current year on DOMContentLoaded', () => {
+    require('../scripts.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    const yearEl = document.getElementById('year');
+    expect(yearEl.textContent).toBe(String(new Date().getFullYear()));
+  });
+});


### PR DESCRIPTION
## Summary
- add package.json with Jest setup
- add unit test for scripts.js using jsdom
- run Node-based tests in CI workflow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484ea51aec8327b603eb8bacc5a8ef