### PR TITLE
Remove stray DOCTYPE from fiction page

### DIFF
--- a/fathering/blog/fiction.index.html
+++ b/fathering/blog/fiction.index.html
@@ -1235,10 +1235,3 @@
     </script>
 </body>
 </html>
-                <!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>The Abraham Chronicles | Fathering Without Fear</title>
-    <link rel="preconnect" href="https://fonts.googleapis


### PR DESCRIPTION
## Summary
- remove second `<!DOCTYPE html>` block from `fiction.index.html`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485cd5b1508327af55f9eb155e2be4