### PR TITLE
Add npm install step before tests

### DIFF
--- a/Project-documentation/directory.test.js
+++ b/Project-documentation/directory.test.js
@@ -98,6 +98,12 @@ abraham-of-london/
 The project uses Jest for testing with jsdom for DOM manipulation testing.
 
 ### Running Tests
+
+Before running tests, install all dependencies to set up Jest and other development tools:
+```bash
+npm install
+```
+
 ```bash
 # Run all tests
 npm test


### PR DESCRIPTION
## Summary
- document that dependencies must be installed before running `npm test`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_6848a2cbfff083279dd1cfa6c2d3f74b