### PR TITLE
Move HTML-based tests into proper Jest file

### DIFF
--- a/tests/functionality.test.js
+++ b/tests/functionality.test.js
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 // Main website functionality tests for Abraham of London
 
 describe('Abraham of London Website', () => {


### PR DESCRIPTION
## Summary
- move `Functionality-test.HTML` into `tests/functionality.test.js`
- ensure the test runs in jsdom

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848abfab2488327bbde3671d09f8d96