### PR TITLE
Add video example and test coverage

### DIFF
--- a/Functionality-test.HTML
+++ b/Functionality-test.HTML
@@ -61,6 +61,10 @@ describe('Abraham of London Website', () => {
           <div class="container">
             <h2 class="section-title">Fathering Wisdom</h2>
             <div class="video-container" id="videoContainer">
+              <video id="fatheringVideo" controls poster="https://via.placeholder.com/640x360.png">
+                <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4">
+                Your browser does not support the video tag.
+              </video>
               <div class="play-button">
                 <i class="fas fa-play"></i>
               </div>

--- a/Tests/Java-Script-Functionality-Tests.js
+++ b/Tests/Java-Script-Functionality-Tests.js
@@ -98,6 +98,10 @@ describe('Website JavaScript Functionality', () => {
       </section>
 
       <div class="video-container" id="videoContainer">
+        <video id="fatheringVideo" controls poster="https://via.placeholder.com/640x360.png">
+          <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4">
+          Your browser does not support the video tag.
+        </video>
         <div class="play-button"></div>
       </div>
 
@@ -267,6 +271,14 @@ describe('Website JavaScript Functionality', () => {
     test('should have play button in video container', () => {
       const playButton = document.querySelector('.play-button');
       expect(playButton).toBeTruthy();
+    });
+
+    test('should load video source', () => {
+      const video = document.querySelector('#videoContainer video');
+      expect(video).toBeTruthy();
+      const source = video.querySelector('source');
+      expect(source).toBeTruthy();
+      expect(source.getAttribute('src')).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
## Summary
- embed a playable video in the DOM mock for Functionality-test.HTML
- update JS mock DOM to include the video element and add tests that verify the video source

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6848b1c5c8c083279130ed7a61f0a949