### PR TITLE
Add assets directory with placeholder images

### DIFF
--- a/assets/favicon/favicon.ico
+++ b/assets/favicon/favicon.ico
@@ -1,0 +1,1 @@
+placeholder

--- a/assets/images/abraham-portrait.webp
+++ b/assets/images/abraham-portrait.webp
@@ -1,0 +1,1 @@
+placeholder

--- a/assets/images/abraham-portrait@2x.webp
+++ b/assets/images/abraham-portrait@2x.webp
@@ -1,0 +1,1 @@
+placeholder

--- a/assets/images/alomarada-logo.svg
+++ b/assets/images/alomarada-logo.svg
@@ -1,0 +1,1 @@
+placeholder

--- a/assets/images/banner.webp
+++ b/assets/images/banner.webp
@@ -1,0 +1,1 @@
+placeholder

--- a/assets/images/endureluxe-icon.webp
+++ b/assets/images/endureluxe-icon.webp
@@ -1,0 +1,1 @@
+placeholder

--- a/assets/images/fwf-badge.svg
+++ b/assets/images/fwf-badge.svg
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Summary
- add `assets/images/` and `assets/favicon/` directories
- include placeholder image files for site assets

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b50555588327a3cb5eb9b691b4ef