### PR TITLE
Fix duplicate markup

### DIFF
--- a/fathering/blog/fiction.index.html
+++ b/fathering/blog/fiction.index.html
@@ -1235,10 +1235,3 @@
     </script>
 </body>
 </html>
-                <!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>The Abraham Chronicles | Fathering Without Fear</title>
-    <link rel="preconnect" href="https://fonts.googleapis


### PR DESCRIPTION
## Summary
- remove extraneous markup from `fathering/blog/fiction.index.html`

## Testing
- `npm test` *(fails: jest not found)*
- `python - <<'EOF'
from html.parser import HTMLParser
parser = HTMLParser()
with open('fathering/blog/fiction.index.html') as f:
    parser.feed(f.read())
print('success')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6848b61c36b88327a1c6c123fb5d6b69