### PR TITLE
Fix truncated duplicate HTML

### DIFF
--- a/fathering/blog/fiction.index.html
+++ b/fathering/blog/fiction.index.html
@@ -1235,10 +1235,3 @@
     </script>
 </body>
 </html>
-                <!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>The Abraham Chronicles | Fathering Without Fear</title>
-    <link rel="preconnect" href="https://fonts.googleapis


### PR DESCRIPTION
## Summary
- trim stray markup from `fiction.index.html`

## Testing
- `python3 - <<'PY'
import sys, html.parser, pathlib
class MyParser(html.parser.HTMLParser):
    def error(self, message):
        print('error', message)

p = MyParser()
text = pathlib.Path('fathering/blog/fiction.index.html').read_text()
try:
    p.feed(text)
    p.close()
    print('HTML parsed successfully')
except Exception as e:
    print('Exception:', e)
PY`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b699c7e48327aff7743666dbefb9