### PR TITLE
Add form submission tests

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -27,4 +27,26 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     });
   });
+
+  const contactForm = document.getElementById("contactForm");
+  if (contactForm) {
+    contactForm.addEventListener("submit", e => {
+      e.preventDefault();
+      const btn = contactForm.querySelector(".submit-button");
+      if (!btn) return;
+      const original = btn.textContent;
+      btn.textContent = "Sending…";
+      btn.disabled = true;
+
+      setTimeout(() => {
+        btn.textContent = "Message Sent!";
+        contactForm.reset();
+
+        setTimeout(() => {
+          btn.textContent = original;
+          btn.disabled = false;
+        }, 1000);
+      }, 1000);
+    });
+  }
 });

--- a/tests/scripts.test.js
+++ b/tests/scripts.test.js
@@ -2,6 +2,8 @@
  * @jest-environment jsdom
  */
 
+const setup = require('../Project-documentation/tests/Jest-Test-Setup Code-setup.js');
+
 describe('scripts.js', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -13,5 +15,39 @@ describe('scripts.js', () => {
     document.dispatchEvent(new Event('DOMContentLoaded'));
     const yearEl = document.getElementById('year');
     expect(yearEl.textContent).toBe(String(new Date().getFullYear()));
+  });
+
+  test('form submission button text changes and fields reset', () => {
+    jest.useFakeTimers();
+
+    document.body.innerHTML = `
+      <form id="contactForm">
+        <input id="name" value="John" />
+        <input id="email" value="john@example.com" />
+        <textarea id="message">Hello</textarea>
+        <button type="submit" class="submit-button">Send Message</button>
+      </form>
+    `;
+
+    require('../scripts.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const form = document.getElementById('contactForm');
+    const button = form.querySelector('.submit-button');
+
+    global.testUtils.simulateEvent(form, 'submit');
+
+    expect(button.textContent).toBe('Sending…');
+
+    jest.advanceTimersByTime(1000);
+    expect(button.textContent).toBe('Message Sent!');
+    expect(form.querySelector('#name').value).toBe('');
+    expect(form.querySelector('#email').value).toBe('');
+    expect(form.querySelector('#message').value).toBe('');
+
+    jest.advanceTimersByTime(1000);
+    expect(button.textContent).toBe('Send Message');
+
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- add contact form handler in `scripts.js`
- test form button text and field reset

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848bdc5f43c8327a138f8eecbb66846