### PR TITLE
Fix duplicate HTML segment

### DIFF
--- a/fathering/blog/fiction.index.html
+++ b/fathering/blog/fiction.index.html
@@ -1235,10 +1235,3 @@
     </script>
 </body>
 </html>
-                <!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>The Abraham Chronicles | Fathering Without Fear</title>
-    <link rel="preconnect" href="https://fonts.googleapis


### PR DESCRIPTION
## Summary
- remove stray DOCTYPE and HTML that appeared after the closing tag in `fathering/blog/fiction.index.html`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c0df1ae083279bd98ca960e3f667