### PR TITLE
Add analyzer script and update package.json

### DIFF
--- a/analyzer.js
+++ b/analyzer.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+
+const htmlPath = 'index.html';
+const cssFile = 'styles.css';
+
+function checkDoctype(content) {
+  if (!content.trim().toLowerCase().startsWith('<!doctype html>')) {
+    console.error('Missing or incorrect DOCTYPE');
+    return false;
+  }
+  return true;
+}
+
+function checkStylesheet(dom) {
+  const link = dom.window.document.querySelector('link[rel="stylesheet"][href]');
+  if (!link || !link.getAttribute('href').includes(cssFile)) {
+    console.error(`Stylesheet link to ${cssFile} not found`);
+    return false;
+  }
+  return true;
+}
+
+function checkImageAlts(dom) {
+  let valid = true;
+  dom.window.document.querySelectorAll('img').forEach(img => {
+    const alt = img.getAttribute('alt');
+    if (!alt || !alt.trim()) {
+      console.error(`Image missing alt attribute: ${img.outerHTML}`);
+      valid = false;
+    }
+  });
+  return valid;
+}
+
+function runChecks() {
+  if (!fs.existsSync(htmlPath)) {
+    console.error(`Cannot find ${htmlPath}`);
+    process.exit(1);
+  }
+
+  const html = fs.readFileSync(htmlPath, 'utf-8');
+  const dom = new JSDOM(html);
+
+  const results = [
+    checkDoctype(html),
+    checkStylesheet(dom),
+    checkImageAlts(dom)
+  ];
+
+  if (results.every(Boolean)) {
+    console.log('All checks passed');
+  } else {
+    process.exitCode = 1;
+  }
+}
+
+runChecks();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "scripts.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "analyze": "node analyzer.js",
+    "serve": "npx http-server -p 8000"
   },
   "keywords": [],
   "author": "",
@@ -12,6 +14,7 @@
   "type": "commonjs",
   "devDependencies": {
     "jest": "^29.7.0",
-    "jsdom": "^22.1.0"
+    "jsdom": "^22.1.0",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add a simple HTML/CSS analyzer
- expose `analyze` and `serve` scripts
- include `jest-environment-jsdom` in dev dependencies

## Testing
- `npm test` *(fails: jest not found)*
- `npm run analyze` *(fails: cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6848c0eb87b8832788d2cf6ed36ecc13