### PR TITLE
Add README and update npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Abraham of London Website
+
+This repository contains the source for the **Abraham of London** website. It is a static site with a small test suite powered by [Jest](https://jestjs.io/).
+
+## Requirements
+
+- Node.js (14 or newer)
+- npm (comes with Node.js)
+
+## Installation
+
+Install the project dependencies:
+
+```bash
+npm install
+```
+
+## Running a Development Server
+
+A simple HTTP server is provided via the `http-server` package. Start it with:
+
+```bash
+npm run serve
+```
+
+This will serve the project at [http://localhost:8000](http://localhost:8000).
+
+## Running Tests
+
+Execute the Jest test suite once:
+
+```bash
+npm test
+```
+
+Or run in watch mode while developing:
+
+```bash
+npm run test:watch
+```
+
+## Project Structure
+
+- `index.html`, `styles.css`, `scripts.js` – main site files
+- `tests/` – Jest tests
+
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "",
   "main": "scripts.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "serve": "http-server -p 8000",
+    "start": "npm run serve",
+    "test:watch": "jest --watch"
   },
   "keywords": [],
   "author": "",
@@ -12,6 +15,8 @@
   "type": "commonjs",
   "devDependencies": {
     "jest": "^29.7.0",
-    "jsdom": "^22.1.0"
+    "jsdom": "^22.1.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "http-server": "^14.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- add setup and usage instructions in README
- add scripts to run a local server and jest in watch mode
- include missing dev dependencies: jest-environment-jsdom and http-server

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c4f18828832781d1f1bda7d6581a