### PR TITLE
Add docs for deployment scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Abraham of London Website
+
+This repository contains the source files for the personal website of Abraham of London. The site is mostly static HTML/CSS/JS with some supporting documentation and test files.
+
+## Deployment Scripts
+
+Two helper scripts are provided in the `scripts/` directory for setting up a WordPress environment with Docker:
+
+- **Update** – builds a local WordPress instance and installs a custom theme along with several plugins. It performs package installation and file generation automatically.
+- **Update-Secure.sh** – a hardened version that uses environment variables and secure defaults. It can start, stop and clean up the Docker based environment.
+
+### Usage
+
+```bash
+# run the basic setup (creates Docker containers and directories)
+./scripts/Update
+
+# or use the secure script with commands
+./scripts/Update-Secure.sh start
+```
+
+### Caution
+
+Both scripts create Docker containers and may install software on your system. Run them only on machines where such modifications are acceptable and review the code before execution.

--- a/scripts/Update
+++ b/scripts/Update
@@ -2,6 +2,7 @@
 # AbrahamofLondon Superbrand Website Deployment Script
 # This script automates the setup and deployment of the AbrahamofLondon website
 
+# WARNING: This script installs software and modifies Docker and system directories. Use with caution on production machines.
 set -e
 
 echo "=== AbrahamofLondon Website Deployment Script ==="

--- a/scripts/Update-Secure.sh
+++ b/scripts/Update-Secure.sh
@@ -3,6 +3,7 @@
 # Abraham of London - Secure WordPress Deployment Script
 # This script sets up a WordPress environment using Docker with secure credentials
 
+# WARNING: This script installs software and modifies Docker and system directories. Use with caution and review the code before running.
 set -euo pipefail  # Exit on error, undefined vars, pipe failures
 
 # Colors for output


### PR DESCRIPTION
## Summary
- document the deployment helper scripts
- move `Update` and `Update-Secure.sh` into a `scripts/` directory
- add caution comments at the top of each script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c65c800c8327be1c01146da3b67f