### PR TITLE
Fix workflow dependency install

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           node-version: '20'
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       - name: Run tests
         run: npm test
       - name: Setup Pages


### PR DESCRIPTION
## Summary
- avoid `npm ci` because repo lacks a lock file
- run `npm install` when installing deps in the CI workflow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c64892a88327afc29013e8997639