### PR TITLE
Fix duplicate closing tags in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,9 +517,7 @@
                 // You can add analytics tracking here
             });
         });
-    </script>
-</body>
-</html>
+  </script>
   
   <!-- Footer -->
   <footer class="footer">


### PR DESCRIPTION
## Summary
- remove stray `</body>` and `</html>` immediately after inline script

## Testing
- `npm test` *(fails: jest not found)*
- parse `index.html` with Python `HTMLParser`

------
https://chatgpt.com/codex/tasks/task_e_684931a9c96c83279c0d54e6bc737085