### PR TITLE
Fix duplicated footer in fiction blog

### DIFF
--- a/fathering/blog/fiction.index.html
+++ b/fathering/blog/fiction.index.html
@@ -1235,10 +1235,3 @@
     </script>
 </body>
 </html>
-                <!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>The Abraham Chronicles | Fathering Without Fear</title>
-    <link rel="preconnect" href="https://fonts.googleapis


### PR DESCRIPTION
## Summary
- remove stray duplicated `<!DOCTYPE html>` section from `fiction.index.html`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493c20149883279659df0e1af15ecc