### PR TITLE
Add Node 18 dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/devcontainers/node:18
+
+# Install any other dependencies if needed
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+    "name": "Node18 Devcontainer",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "editor.formatOnSave": true,
+                "editor.defaultFormatter": "esbenp.prettier-vscode",
+                "editor.codeActionsOnSave": {
+                    "source.fixAll.eslint": true
+                }
+            },
+            "extensions": [
+                "esbenp.prettier-vscode",
+                "dbaeumer.vscode-eslint",
+                "github.vscode-pull-request-github",
+                "github.copilot"
+            ]
+        }
+    },
+    "postCreateCommand": "npm install",
+    "forwardPorts": [3000]
+}

--- a/.devcontainer/extensions.json
+++ b/.devcontainer/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "github.vscode-pull-request-github",
+        "github.copilot"
+    ]
+}

--- a/.devcontainer/settings.json
+++ b/.devcontainer/settings.json
@@ -1,0 +1,7 @@
+{
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    }
+}


### PR DESCRIPTION
## Summary
- add Node 18 devcontainer setup
- configure VS Code tooling for Prettier, ESLint and GitHub extensions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684946ac4b4c83278f1e2a08695a924c