### PR TITLE
Fix CI install commands

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           node-version: '20'
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       - name: Run tests
         run: npm test
       - name: Setup Pages

--- a/Tests/Test- and -Deploy.yml
+++ b/Tests/Test- and -Deploy.yml
@@ -25,7 +25,7 @@ jobs:
         cache: 'npm'
         
     - name: Install dependencies
-      run: npm ci
+      run: npm install
       
     - name: Run linter
       run: npm run lint
@@ -64,7 +64,7 @@ jobs:
         cache: 'npm'
         
     - name: Install dependencies
-      run: npm ci
+      run: npm install
       
     - name: Run security audit
       run: npm audit --audit-level=moderate
@@ -90,7 +90,7 @@ jobs:
         cache: 'npm'
         
     - name: Install dependencies
-      run: npm ci
+      run: npm install
       
     - name: Build project
       run: npm run build


### PR DESCRIPTION
## Summary
- use `npm install` instead of `npm ci` in GitHub workflows

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm install` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68494b063f18832795798e38a59c5cbf