### PR TITLE
Move functionality test to Jest

### DIFF
--- a/tests/functionality.test.js
+++ b/tests/functionality.test.js
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 // Main website functionality tests for Abraham of London
 
 describe('Abraham of London Website', () => {


### PR DESCRIPTION
## Summary
- move `Functionality-test.HTML` into `tests/` as `functionality.test.js`
- ensure Jest runs in jsdom for the moved test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494b0d0ff083279f96cc3a3e06c034