### PR TITLE
Add task runner and email notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Task Runner
+
+This project includes a `task-runner.js` script that sequentially runs lint, test and compile steps and emails a summary log when all tasks pass.
+
+## Configuration
+
+Create a `.env` file in the project root with your SMTP settings:
+
+```
+SMTP_HOST=your.smtp.host
+SMTP_PORT=587
+SMTP_SECURE=false # set to true if using TLS/SSL
+SMTP_USER=your_username
+SMTP_PASS=your_password
+SMTP_FROM=sender@example.com
+SMTP_TO=recipient@example.com
+```
+
+The email step is skipped if `SMTP_HOST` is not defined.
+
+## Running the tasks
+
+Install dependencies and run:
+
+```bash
+npm run run-tasks
+```
+
+The log output is stored in `task-summary.log` and, if configured, emailed to the address specified in `SMTP_TO`.

--- a/package.json
+++ b/package.json
@@ -4,12 +4,19 @@
   "description": "",
   "main": "scripts.js",
   "scripts": {
-    "test": "jest"
+    "lint": "eslint .",
+    "test": "jest",
+    "compile": "echo \"(optional) build step here\"",
+    "run-tasks": "node task-runner.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^16.3.1",
+    "nodemailer": "^6.9.11"
+  },
   "devDependencies": {
     "jest": "^29.7.0",
     "jsdom": "^22.1.0"

--- a/task-runner.js
+++ b/task-runner.js
@@ -1,0 +1,77 @@
+const { exec } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config();
+const nodemailer = require('nodemailer');
+
+// Environment checks
+if (parseInt(process.versions.node.split('.')[0], 10) < 14) {
+  console.error('Node.js 14 or higher is required.');
+  process.exit(1);
+}
+
+const logFile = path.join(__dirname, 'task-summary.log');
+function log(message) {
+  fs.appendFileSync(logFile, message + '\n');
+}
+
+function runCommand(command, label) {
+  return new Promise((resolve, reject) => {
+    log(`\nRunning: ${command}`);
+    const child = exec(command, { env: process.env }, (error, stdout, stderr) => {
+      if (stdout) log(stdout.trim());
+      if (stderr) log(stderr.trim());
+      if (error) {
+        log(`${label} failed`);
+        return reject(error);
+      }
+      log(`${label} succeeded`);
+      resolve();
+    });
+  });
+}
+
+async function main() {
+  try {
+    await runCommand('npm run lint', 'Lint');
+    await runCommand('npm test', 'Test');
+
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'));
+    if (pkg.scripts && pkg.scripts.compile) {
+      await runCommand('npm run compile', 'Compile');
+    } else {
+      log('Compile step skipped');
+    }
+
+    await sendEmail();
+    console.log('All tasks completed successfully.');
+  } catch (err) {
+    console.error('Task runner failed. See log for details.');
+  }
+}
+
+async function sendEmail() {
+  if (!process.env.SMTP_HOST) {
+    log('SMTP configuration missing, skipping email notification.');
+    return;
+  }
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: parseInt(process.env.SMTP_PORT || '587', 10),
+    secure: process.env.SMTP_SECURE === 'true',
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  });
+
+  await transporter.sendMail({
+    from: process.env.SMTP_FROM,
+    to: process.env.SMTP_TO,
+    subject: 'Task Summary Log',
+    text: fs.readFileSync(logFile, 'utf8'),
+  });
+  log('Log emailed successfully');
+}
+
+main();


### PR DESCRIPTION
## Summary
- implement `task-runner.js` to run lint, test and optional compile steps
- add dotenv and nodemailer dependencies
- provide scripts in `package.json`
- document environment variables and usage in `README.md`

## Testing
- `npm run run-tasks` *(fails: Cannot find module 'dotenv')*
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68494c672db88327918190cdcf18f1fb