### PR TITLE
Update Node version

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '18'
       - name: Install dependencies
         run: npm ci
       - name: Run tests


### PR DESCRIPTION
## Summary
- use Node 18 for the GitHub Actions workflow
- keep dependencies installed with `npm ci` and deploy using `actions/deploy-pages@v4`

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: missing package-lock.json)*

------
https://chatgpt.com/codex/tasks/task_e_68494c8c48948327adb2aca9ef9ba197