### PR TITLE
Add Jest config, ESLint rules and sample test

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,10 +4,14 @@
     "es2021": true,
     "jest": true
   },
-  "extends": "eslint:recommended",
+  "extends": ["eslint:recommended"],
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "rules": {}
+  "rules": {
+    "no-unused-vars": "warn",
+    "semi": ["error", "never"],
+    "no-console": "off"
+  }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,6 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "semi": false,
+  "tabWidth": 2,
+  "trailingComma": "none"
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+  testEnvironment: 'jsdom',
+  transform: {}
+}

--- a/tests/sample.test.js
+++ b/tests/sample.test.js
@@ -1,0 +1,5 @@
+test('Button is present in DOM', () => {
+  document.body.innerHTML = '<button id="clickMe">Click</button>'
+  const btn = document.getElementById('clickMe')
+  expect(btn).not.toBeNull()
+})


### PR DESCRIPTION
## Summary
- add `jest.config.js` for jsdom tests
- expand ESLint rules and update Prettier options
- include a minimal sample test

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495d7264c08327a88b8a6a86f73393