### PR TITLE
Add README with offline setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Abraham of London Website
+
+This repository contains the source code for the **Abraham of London** website.
+
+## Offline Setup
+
+All Node.js dependencies are provided in the archive `abrahamoflondon-node_modules.tar.gz` so that the project can be used without internet access.
+
+### Extract dependencies
+
+1. Place `abrahamoflondon-node_modules.tar.gz` in the repository root.
+2. Extract it using:
+   ```bash
+   tar -xzf abrahamoflondon-node_modules.tar.gz
+   ```
+   This creates the `node_modules` directory used by npm.
+
+### Verify `node_modules` and `package-lock.json`
+
+Run `npm ci --offline --ignore-scripts` to verify the extracted modules match `package-lock.json`:
+```bash
+npm ci --offline --ignore-scripts
+```
+If the command exits without errors, the installed modules are consistent with the lock file.
+
+## Running the project
+
+After extraction you can run the common npm scripts completely offline:
+
+- **Tests**
+  ```bash
+  npm test
+  ```
+- **Linting**
+  ```bash
+  npm run lint
+  ```
+- **Start the server**
+  ```bash
+  npm start
+  ```
+
+`npm start` serves the site locally using `serve` on port 3000.
+


### PR DESCRIPTION
## Summary
- document how to set up the project offline
- cover extracting the node_modules archive and running npm scripts

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config issue)*
- `npm start` *(fails: serve not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849636931848327a297cbf75e8baf7e