### PR TITLE
Rename HTML test to JS for Jest

### DIFF
--- a/functionality.full.test.js
+++ b/functionality.full.test.js
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 // Main website functionality tests for Abraham of London
 
 describe('Abraham of London Website', () => {


### PR DESCRIPTION
## Summary
- rename `Functionality-test.HTML` to `functionality.full.test.js`
- ensure Jest uses jsdom for the renamed test

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849636da8248327a93ebfce6f290f8f